### PR TITLE
fix: OIDC trust policy to allow more actions

### DIFF
--- a/modules/github-oidc-trust/main.tf
+++ b/modules/github-oidc-trust/main.tf
@@ -24,16 +24,12 @@ data "aws_iam_policy_document" "this" {
       variable = "token.actions.githubusercontent.com:aud"
       values   = ["sts.amazonaws.com"]
     }
-    dynamic "condition" {
-      for_each = var.trusted_repos
-      content {
-        test     = "StringLike"
-        variable = "token.actions.githubusercontent.com:sub"
-        values = [
-          "repo:${var.github_org}/${condition.value}:ref:refs/heads/main",
-          "repo:${var.github_org}/${condition.value}:pull_request"
-        ]
-      }
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      # This is crucial, without this condition any action (even outside of our org)
+      # can assume any IAM role with such a trust policy
+      values = [for repo in var.trusted_repos: "repo:${var.github_org}/${repo}:*"]
     }
   }
 }

--- a/modules/s3/deployment.tf
+++ b/modules/s3/deployment.tf
@@ -34,8 +34,8 @@ data "aws_iam_policy_document" "deploy_permissions" {
 
     effect = "Allow"
     actions = [
-      # TODO not sure if this permission is sufficient
-      "lambda:UpdateFunctionCode"
+      "lambda:UpdateFunctionCode",
+      "lambda:GetFunctionConfiguration"
     ]
     resources = [
       aws_lambda_function.locations.arn,


### PR DESCRIPTION
What and why?
We are using manually triggered GHA workflows. Those were previously not allowed to assume our deployment role. With this change, this is now possible.

We add a missing permission to the deployment role in order to be able to perform the `aws lambda wait function-updated` command in our CI.